### PR TITLE
fix: fish disable history based autosuggestions

### DIFF
--- a/src/pty.rs
+++ b/src/pty.rs
@@ -171,6 +171,7 @@ impl FishRuntime {
         let config_path = home.join("fish/config.fish");
         let config = "\
 set -U fish_greeting \"\"
+set -U fish_autosuggestion_enabled 0
 function fish_title
 end
 function fish_prompt


### PR DESCRIPTION
These only introduce unnecessary noise as they are not based on completion but on history.