### PR TITLE
fix(zsh): Do not read global /etc/zshrc for better isolation

### DIFF
--- a/src/pty.rs
+++ b/src/pty.rs
@@ -63,6 +63,7 @@ PROMPT='%% '
     /// Get the output from typing `input` into the shell
     pub fn complete(&mut self, input: &str, term: &Term) -> std::io::Result<String> {
         let mut command = Command::new("zsh");
+        command.arg("--noglobalrcs");
         command.env("PATH", &self.path).env("ZDOTDIR", &self.home);
         let echo = false;
         comptest(command, echo, input, term, self.timeout)


### PR DESCRIPTION
My `/etc/zshrc` sets `PS1="%n@%m %1~ %# "` which ends up in the final output.  This PR adds an option that prevents reading global zsh configuration file.  See https://zsh.sourceforge.io/Doc/Release/Files.html